### PR TITLE
Start on role commands

### DIFF
--- a/src/MatoStreamshow.py
+++ b/src/MatoStreamshow.py
@@ -113,22 +113,23 @@ class MatoStreamshow(discord.Client):
                         await m.remove_roles(dlr, reason="Not Streaming Live")
             streams = api.get_streams(stream_type="live", user_login=l, first=100)
             async for stream in streams:
-                if len(cats) == 0 or stream.game_name in cats:
-                    if not stream.user_name in live_info:
-                        url = "https://www.twitch.tv/" + stream.user_name
-                        thumb = stream.thumbnail_url.replace("{width}", "320").replace("{height}", "180")
-                        if not thumbnail_url_template:
-                            thumbnail_url_template = guess_thumbnail_url_template(stream.user_name, thumb)
-                        elif guess_thumbnail_url(stream.user_name, thumbnail_url_template) != thumb:
-                            thumbnail_url_template = None
-                        live_info[stream.user_name] = LiveInfo(
-                            display=stream.user_name,
-                            user_name=stream.user_name,
-                            game_name=stream.game_name,
-                            title=stream.title,
-                            url=url,
-                            thumbnail_url=thumb,
-                        )
+                thumb = stream.thumbnail_url.replace("{width}", "320").replace("{height}", "180")
+                if not thumbnail_url_template:
+                    thumbnail_url_template = guess_thumbnail_url_template(stream.user_name, thumb)
+                    print("thumbnail_url_template: " + thumbnail_url_template)
+                elif guess_thumbnail_url(stream.user_name, thumbnail_url_template) != thumb:
+                    print("invalid thumbnail_url_template: " + thumbnail_url_template)
+                    thumbnail_url_template = None
+                if (not stream.user_name in live_info) and (len(cats) == 0 or stream.game_name in cats):
+                    url = "https://www.twitch.tv/" + stream.user_name
+                    live_info[stream.user_name] = LiveInfo(
+                        display=stream.user_name,
+                        user_name=stream.user_name,
+                        game_name=stream.game_name,
+                        title=stream.title,
+                        url=url,
+                        thumbnail_url=thumb,
+                    )
             dcms = {}
             async for m in dc.history():
                 if m.author.id == self.user.id:

--- a/src/MatoStreamshow.py
+++ b/src/MatoStreamshow.py
@@ -141,7 +141,7 @@ class MatoStreamshow(discord.Client):
                         dcms[name] = m
             for name, info in live_info.items():
                 plain_game = plain(info.game_name)
-                text = "**" + plain(info.user_name) + "** is live! Playing " + plain_game
+                text = "**" + plain(info.display) + "** is live! Playing " + plain_game
                 title = plain(info.title)
                 thumb = info.thumbnail_url or guess_thumbnail_url(info.user_name, thumbnail_url_template)
                 if info.user_name in dcms:

--- a/src/save.py
+++ b/src/save.py
@@ -6,6 +6,8 @@ FULL_TEMPLATE = {
     "guild_template": {
         "name": "",  # Note: automatically set to guild name on addition
         "channel_id": 0,
+        "streamer_role_id": 0,
+        "live_role_id": 0,
         "twitch_streamer_list": [],
         "twitch_category_list": []
     },


### PR DESCRIPTION
Features:
- `/streamer-role` Sets the role to check streams for.
- `/live-role` Sets the role to grant streamers when live.

Testing:
- [x] Remove live role from someone not currently streaming.
- [x] Add live role to someone currently streaming.

Implementation tasks:
- [x] Send a message when a streamer goes live.
- [x] Delete such a message when the streamer is no longer live.