### PR TITLE
Rely more on event-based operations for Discord activity presence, less on poll-based operations

### DIFF
--- a/src/MatoStreamshow.py
+++ b/src/MatoStreamshow.py
@@ -386,6 +386,9 @@ class MatoStreamshow(discord.Client):
                 if not g in server_live_infoss:
                     server_live_infoss[g] = {}
                 server_live_infos = server_live_infoss[g]
+                if not g in server_live_memberss:
+                    server_live_memberss[g] = {}
+                server_live_members = server_live_memberss[g]
                 dc = bot.get_channel(dc_id)
                 if not isinstance(dc, discord.TextChannel):
                     continue
@@ -423,6 +426,20 @@ class MatoStreamshow(discord.Client):
                         if not name in server_live_infos:
                             await server_channel_msgs[name].delete()
                             server_channel_msgs.pop(name, None)
+                            if name in server_live_members:
+                                guild = self.get_guild(int(g))
+                                dlr_id = d["live_role_id"]
+                                try:
+                                    if dlr_id and dlr_id != 0:
+                                        dlr = guild and guild.get_role(dlr_id)
+                                        if dlr:
+                                            await server_live_members[name].remove_roles(dlr)
+                                            server_live_members.pop(name, None)
+                                except discord.Forbidden as e:
+                                    print("MatoStreamshow needs permission to manage the live role in:")
+                                    print("  Server name: " + d["name"])
+                                    print("  Role id: " + str(dlr_id), flush=True)
+                                    traceback.print_exception(e)
 
             #endregion Discord messages
 

--- a/src/MatoStreamshow.py
+++ b/src/MatoStreamshow.py
@@ -115,7 +115,6 @@ class MatoStreamshow(discord.Client):
                 dc_id = d["channel_id"]
                 if not (dc_id and dc_id != 0):
                     continue
-                cap_l = d["twitch_streamer_list"]
                 cats = d["twitch_category_list"]
                 if not "streamer_roles" in d:
                     d["streamer_roles"] = { str(d["streamer_role_id"]): False } if ("streamer_role_id" in d and d["streamer_role_id"]) else {}

--- a/src/MatoStreamshow.py
+++ b/src/MatoStreamshow.py
@@ -375,6 +375,7 @@ class MatoStreamshow(discord.Client):
         if has_any_of_role_ids(m, muted_role_list):
             return
         cats = d["twitch_category_list"]
+        dlr_id = d["live_role_id"]
         if not g in server_live_infoss:
             server_live_infoss[g] = {}
         server_live_infos = server_live_infoss[g]
@@ -415,21 +416,21 @@ class MatoStreamshow(discord.Client):
                             has_streamer_role=True,
                         )
                     break
-        if not is_live:
+        if is_live:
+            if dlr_id and dlr_id != 0:
+                try:
+                    if not m.get_role(dlr_id):
+                        dlr = guild.get_role(dlr_id)
+                        if dlr:
+                            await m.add_roles(dlr, reason="Streaming Live")
+                except discord.Forbidden as e:
+                    print("MatoStreamshow needs permission to manage the live role in:")
+                    print("  Server name: " + d["name"])
+                    print("  Role id: " + str(dlr_id), flush=True)
+                    traceback.print_exception(e)
+            await ensure_message(g, lower_name)
+        else:
             return
-        dlr_id = d["live_role_id"]
-        if dlr_id and dlr_id != 0:
-            try:
-                if not m.get_role(dlr_id):
-                    dlr = guild.get_role(dlr_id)
-                    if dlr:
-                        await m.add_roles(dlr, reason="Streaming Live")
-            except discord.Forbidden as e:
-                print("MatoStreamshow needs permission to manage the live role in:")
-                print("  Server name: " + d["name"])
-                print("  Role id: " + str(dlr_id), flush=True)
-                traceback.print_exception(e)
-        await ensure_message(g, lower_name)
 
 async def ensure_message(g, name):
     global thumbnail_url_template

--- a/src/MatoStreamshow.py
+++ b/src/MatoStreamshow.py
@@ -294,11 +294,12 @@ class MatoStreamshow(discord.Client):
                     if lower_name in global_valid_keys:
                         stream = global_live_infos[lower_name]
                         if (not lower_name in server_valid_keys) and (len(cats) == 0 or stream.game_name in cats):
-                            server_live_infos[lower_name] = ServerLiveInfo(
-                                display_name=cap_name,
-                                display_avatar=None,
-                                has_streamer_role=False,
-                            )
+                            if not lower_name in server_live_infos:
+                                server_live_infos[lower_name] = ServerLiveInfo(
+                                    display_name=cap_name,
+                                    display_avatar=None,
+                                    has_streamer_role=False,
+                                )
                             server_valid_keys.add(lower_name)
                 if not hadTwitchBackendException:
                     for lower_name in set(server_live_infos.keys()):

--- a/src/MatoStreamshow.py
+++ b/src/MatoStreamshow.py
@@ -155,7 +155,8 @@ class MatoStreamshow(discord.Client):
                     if not g in server_live_infoss:
                         server_live_infoss[g] = {}
                     server_live_infos = server_live_infoss[g]
-                    server_valid_keyss[g] = set()
+                    if not g in server_valid_keyss:
+                        server_valid_keyss[g] = set()
                     server_valid_keys = server_valid_keyss[g]
                     streamer_members: set[discord.Member] = set()
                     live_members: set[discord.Member] = set()
@@ -283,6 +284,8 @@ class MatoStreamshow(discord.Client):
                 if not g in server_live_infoss:
                     server_live_infoss[g] = {}
                 server_live_infos = server_live_infoss[g]
+                if not g in server_valid_keyss:
+                    server_valid_keyss[g] = set()
                 server_valid_keys = server_valid_keyss[g]
                 cap_l = d["twitch_streamer_list"]
                 cats = d["twitch_category_list"]

--- a/src/MatoStreamshow.py
+++ b/src/MatoStreamshow.py
@@ -132,6 +132,7 @@ class MatoStreamshow(discord.Client):
 
             #region Discord activity presence and roles
 
+            listened_discord = False
             for g in save.get_guild_ids():
                 d = save.get_guild_data(g)
                 dc_id = d["channel_id"]
@@ -213,6 +214,7 @@ class MatoStreamshow(discord.Client):
                     print("  Server name: " + d["name"])
                     print("  Role id: " + str(dlr_id), flush=True)
                     traceback.print_exception(e)
+            listened_discord = True
 
             #endregion Discord activity presence and roles
 
@@ -289,9 +291,12 @@ class MatoStreamshow(discord.Client):
                             server_valid_keys.add(lower_name)
                 if not hadTwitchBackendException:
                     for lower_name in set(server_live_infos.keys()):
-                        # TODO: tweak this condition to avoid deleting
-                        # entries from Discord that weren't from Twitch
-                        if not lower_name in server_valid_keys:
+                        # This condition is here to avoid deleting
+                        # entries from Discord that weren't from Twitch,
+                        # when it hasn't listened to Discord fully this time.
+                        # Only delete entries when either listened_discord,
+                        # or it's not from Twitch.
+                        if (not lower_name in server_valid_keys) and (listened_discord or not (lower_name in global_live_infos and global_live_infos[lower_name].from_twitch_api)):
                             server_live_infos.pop(lower_name, None)
 
             #region Twitch profile image avatars

--- a/src/MatoStreamshow.py
+++ b/src/MatoStreamshow.py
@@ -429,8 +429,31 @@ class MatoStreamshow(discord.Client):
                     print("  Role id: " + str(dlr_id), flush=True)
                     traceback.print_exception(e)
             await ensure_message(g, lower_name)
-        else:
-            return
+        elif lower_name in global_live_infos and not global_live_infos[lower_name].from_twitch_api:
+            if dlr_id and dlr_id != 0:
+                try:
+                    dlr = m.get_role(dlr_id)
+                    if dlr:
+                        await m.remove_roles(dlr, reason="Not Streaming Live")
+                except discord.Forbidden as e:
+                    print("MatoStreamshow needs permission to manage the live role in:")
+                    print("  Server name: " + d["name"])
+                    print("  Role id: " + str(dlr_id), flush=True)
+                    traceback.print_exception(e)
+            server_live_infos.pop(lower_name, None)
+            any_left = False
+            for server_infos in server_live_infoss:
+                if lower_name in server_infos:
+                    any_left = True
+                    break
+            if not any_left:
+                global_live_infos.pop(lower_name, None)
+            if not g in server_channel_msgss:
+                server_channel_msgss[g] = {}
+            server_channel_msgs = server_channel_msgss[g]
+            msg = server_channel_msgs.pop(lower_name)
+            if msg:
+                await msg.delete()
 
 async def ensure_message(g, name):
     global thumbnail_url_template

--- a/src/MatoStreamshow.py
+++ b/src/MatoStreamshow.py
@@ -280,6 +280,8 @@ class MatoStreamshow(discord.Client):
                 dc_id = d["channel_id"]
                 if not (dc_id and dc_id != 0):
                     continue
+                if not g in server_live_infoss:
+                    server_live_infoss[g] = {}
                 server_live_infos = server_live_infoss[g]
                 server_valid_keys = server_valid_keyss[g]
                 cap_l = d["twitch_streamer_list"]
@@ -313,6 +315,8 @@ class MatoStreamshow(discord.Client):
                 dc_id = d["channel_id"]
                 if not (dc_id and dc_id != 0):
                     continue
+                if not g in server_live_infoss:
+                    server_live_infoss[g] = {}
                 server_live_infos = server_live_infoss[g]
                 avatar_unknowns.update((u for u, i in server_live_infos.items() if i.display_avatar == None))
             try:
@@ -364,6 +368,8 @@ class MatoStreamshow(discord.Client):
                 if not (dc_id and dc_id != 0):
                     continue
                 cap_l = d["twitch_streamer_list"]
+                if not g in server_live_infoss:
+                    server_live_infoss[g] = {}
                 server_live_infos = server_live_infoss[g]
                 dc = bot.get_channel(dc_id)
                 if not isinstance(dc, discord.TextChannel):
@@ -525,6 +531,8 @@ async def ensure_message(g, name):
     if not (dc_id and dc_id != 0):
         return
     cap_l = d["twitch_streamer_list"]
+    if not g in server_live_infoss:
+        server_live_infoss[g] = {}
     server_live_infos = server_live_infoss[g]
     dc = bot.get_channel(dc_id)
     if not isinstance(dc, discord.TextChannel):

--- a/src/MatoStreamshow.py
+++ b/src/MatoStreamshow.py
@@ -129,6 +129,9 @@ class MatoStreamshow(discord.Client):
         global_valid_keys: set[str] = set()
         server_valid_keyss: dict[str, set[str]] = {}
         try:
+
+            #region Discord activity presence and roles
+
             for g in save.get_guild_ids():
                 d = save.get_guild_data(g)
                 dc_id = d["channel_id"]
@@ -210,6 +213,9 @@ class MatoStreamshow(discord.Client):
                     print("  Server name: " + d["name"])
                     print("  Role id: " + str(dlr_id), flush=True)
                     traceback.print_exception(e)
+
+            #endregion Discord activity presence and roles
+
             lower_set_all: set[str] = set()
             for g in save.get_guild_ids():
                 d = save.get_guild_data(g)
@@ -218,6 +224,9 @@ class MatoStreamshow(discord.Client):
                     continue
                 cap_l = d["twitch_streamer_list"]
                 lower_set_all.update((u.casefold() for u in cap_l))
+
+            #region Twitch streams
+
             hadTwitchBackendException = False
             try:
                 if api:
@@ -255,6 +264,9 @@ class MatoStreamshow(discord.Client):
                 hadTwitchBackendException = True
                 print("Twitch API Server Error in TwitchListen", flush=True)
                 traceback.print_exception(e)
+
+            #endregion Twitch streams
+
             for g in save.get_guild_ids():
                 d = save.get_guild_data(g)
                 dc_id = d["channel_id"]
@@ -281,6 +293,9 @@ class MatoStreamshow(discord.Client):
                         # entries from Discord that weren't from Twitch
                         if not lower_name in server_valid_keys:
                             server_live_infos.pop(lower_name, None)
+
+            #region Twitch profile image avatars
+
             avatar_unknowns = set()
             for g in save.get_guild_ids():
                 d = save.get_guild_data(g)
@@ -301,6 +316,11 @@ class MatoStreamshow(discord.Client):
                 hadTwitchBackendException = True
                 print("Twitch API Server Error in TwitchListen", flush=True)
                 traceback.print_exception(e)
+
+            #endregion Twitch profile image avatars
+
+            #region Twitch game image box art
+
             game_image_unknowns = set()
             for global_info in global_live_infos.values():
                 if global_info.game_name in global_game_images:
@@ -322,6 +342,11 @@ class MatoStreamshow(discord.Client):
                 hadTwitchBackendException = True
                 print("Twitch API Server Error in TwitchListen", flush=True)
                 traceback.print_exception(e)
+
+            #endregion Twitch game image box art
+
+            #region Discord messages
+
             for g in save.get_guild_ids():
                 d = save.get_guild_data(g)
                 dc_id = d["channel_id"]
@@ -366,6 +391,9 @@ class MatoStreamshow(discord.Client):
                         if not name in server_live_infos:
                             await server_channel_msgs[name].delete()
                             server_channel_msgs.pop(name, None)
+
+            #endregion Discord messages
+
         except discord.DiscordServerError as e:
             print("Discord Server Error in TwitchListen", flush=True)
             traceback.print_exception(e)

--- a/src/MatoStreamshow.py
+++ b/src/MatoStreamshow.py
@@ -26,9 +26,28 @@ if (not config.twitch_api_secret) or config.twitch_api_secret == "":
 
 # Twitch info processing
 
-GlobalLiveInfo = namedtuple('GlobalLiveInfo', ['game_name', 'title', 'url', 'thumbnail_url', 'profile_image_url', 'started_at', 'game_image_url', 'from_twitch_api'])
+GlobalLiveInfo = namedtuple(
+    "GlobalLiveInfo",
+    [
+        "game_name",
+        "title",
+        "url",
+        "thumbnail_url",
+        "profile_image_url",
+        "started_at",
+        "game_image_url",
+        "from_twitch_api",
+    ],
+)
 
-ServerLiveInfo = namedtuple('ServerLiveInfo', ['display_name', 'display_avatar', 'has_streamer_role'])
+ServerLiveInfo = namedtuple(
+    "ServerLiveInfo",
+    [
+        "display_name",
+        "display_avatar",
+        "has_streamer_role",
+    ],
+)
 
 global_live_infos: dict[str, GlobalLiveInfo] = {}
 global_game_images: dict[str, str] = {}

--- a/src/MatoStreamshow.py
+++ b/src/MatoStreamshow.py
@@ -258,6 +258,8 @@ class MatoStreamshow(discord.Client):
                             server_valid_keys.add(lower_name)
                 if not hadTwitchBackendException:
                     for lower_name in set(server_live_infos.keys()):
+                        # TODO: tweak this condition to avoid deleting
+                        # entries from Discord that weren't from Twitch
                         if not lower_name in server_valid_keys:
                             server_live_infos.pop(lower_name, None)
             avatar_unknowns = set()


### PR DESCRIPTION
Still keep some poll-based operations, but limit them to about every hour.

Fixes #10 